### PR TITLE
Add restricted-ssh-commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ You can then, among other things:
 | `sshd_restrict_users` | `False` | Whether to restrict ssh logins to members of a certain group |
 | `sshd_manage_restriction_group` | `True` | Whether to actively manage the ssh restriction group (disable if it is in e.g. LDAP) |
 | `sshd_restriction_group` | `sshusers` | Name of the ssh restriction group |
+| `sshd_restricted_commands` | undefined | Restrict commands for certain user+key combinations (see restricted-ssh-commands section and defaults/main.yml |
 | `sshd_allowed_users` | `["root"]` | User to add to ssh restriction group |
 | `sshd_permit_root_login` | `prohibit-password` | Whether to permit root login |
 | `sshd_additional_user_cfg` | `[]` | Besides root, additionally deploy keys or kerberos principals for these users. Have a look at (defaults/main.yml) for formatting |
@@ -48,6 +49,18 @@ In particular these are following files:
   * `recovery`: special recovery key in case the IAM (FreeIPA) fails. To deploy set `ssh_deploy_recovery_key` to True.
 
 The `backup` key configured in the `sshd_config` is deployed by the **backup_client** role.
+
+## Restricted-ssh-commands
+You can restrict the commands a user with a certain key can execute per user.
+This uses [restricted-ssh-commands](https://packages.debian.org/buster/restricted-ssh-commands).
+
+**Example** You have a key `key1` that is authorized to login as `root` but you
+want to only allow it to execute e. g. apt-commands.
+
+1. Add dictionairy entry in `sshd_restricted_commands` with `user: root` and
+command `commands: - "^apt"`.
+2. Prefix the ssh-key with `command="/usr/lib/restricted-ssh-commands",no-port-forwarding,no-X11-forwarding,no-agent-forwarding,no-pty ssh-rsa [...]`
+**Only keys with that prefix will be affected by the restriction!**
 
 ## License
 GPLv3

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -62,6 +62,14 @@ sshd_allowed_users:
 # If login restrictions are enabled, how shall the group be called?
 sshd_restriction_group: sshusers
 
+# Restrict the commands a SSH user can execute, see README
+# sshd_restricted_commands:
+#   - user: root
+#     commands:
+#       - "^scp -p( -d)? -t( --)? /srv/reprepro/incoming(/[-a-z0-9+~_.]*[-a-z0-9+~_])?$"
+#       - "^chmod 0644( /srv/reprepro/incoming/[-a-z0-9+~_.]*[-a-z0-9+~_])+$"
+#       - "^reprepro ( -V)? -b /srv/reprepro processincoming foobar$"
+
 # Whether to allow root login
 sshd_permit_root_login: "prohibit-password"
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -114,4 +114,26 @@
       content: "{{ lookup('file', sshd_moduli_name) }}"
     notify: restart ssh
 
+  - name: Install restricted-ssh-commands
+    when: sshd_restricted_commands is defined
+    become: True
+    apt:
+      name: restricted-ssh-commands
+      state: present
+
+  - name: Ensure restricted-ssh-commands directory exists
+    when: sshd_restricted_commands is defined
+    become: True
+    file:
+      path: "/etc/restricted-ssh-commands"
+      state: directory
+
+  - name: Write restricted-ssh-commands configs
+    become: True
+    when: sshd_restricted_commands is defined
+    template:
+      src: restricted-ssh-commands.j2
+      dest: "/etc/restricted-ssh-commands/{{ item.user }}"
+    loop: "{{ sshd_restricted_commands }}"
+
   - meta: flush_handlers

--- a/templates/restricted-ssh-commands.j2
+++ b/templates/restricted-ssh-commands.j2
@@ -1,0 +1,3 @@
+{% for item in item.commands %}
+{{ item }}
+{% endfor %}


### PR DESCRIPTION
This pull request adds the option to restrict SSH commands that can be executed per user-key-combination. It uses [restricted-ssh-commands](https://packages.debian.org/buster/restricted-ssh-commands).